### PR TITLE
Upgrade projects to .NET 8

### DIFF
--- a/EncoderLib.Tests/EncoderLib.Tests.vbproj
+++ b/EncoderLib.Tests/EncoderLib.Tests.vbproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EncoderLib/EncoderLib.vbproj
+++ b/EncoderLib/EncoderLib.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>EncoderLib</RootNamespace>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/EncoderWpfApp/EncoderWpfApp.vbproj
+++ b/EncoderWpfApp/EncoderWpfApp.vbproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <RootNamespace>EncoderWpfApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- target library and WPF app for .NET 8
- update unit test dependencies

## Testing
- `dotnet test`
- `dotnet build EncoderWpfApp/EncoderWpfApp.vbproj -p:Configuration=Release` *(fails: Type 'Application' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897451f848883338708fd301c1338dd