### PR TITLE
Add key-combo mapping and hardware simulator

### DIFF
--- a/EncoderLib.Tests/AppSettingsTests.vb
+++ b/EncoderLib.Tests/AppSettingsTests.vb
@@ -18,16 +18,16 @@ Public Class AppSettingsTests
             .Autostart = True,
             .ComPort = "COM7",
             .KeyMapping = New KeyMapper() With {
-                .RotateUp = WindowsKey.PageUp,
-                .ButtonPress = WindowsKey.Escape
+                .RotateUp = "PageUp",
+                .ButtonPress = "Escape"
             }
         }
         settings.Save(dir)
         Dim loaded = AppSettings.Load(dir)
         Assert.IsTrue(loaded.Autostart)
         Assert.AreEqual("COM7", loaded.ComPort)
-        Assert.AreEqual(WindowsKey.PageUp, loaded.KeyMapping.RotateUp)
-        Assert.AreEqual(WindowsKey.Escape, loaded.KeyMapping.ButtonPress)
+        Assert.AreEqual("PageUp", loaded.KeyMapping.RotateUp)
+        Assert.AreEqual("Escape", loaded.KeyMapping.ButtonPress)
     End Sub
 
 End Class

--- a/EncoderLib.Tests/AppSettingsTests.vb
+++ b/EncoderLib.Tests/AppSettingsTests.vb
@@ -4,7 +4,7 @@ Imports System.IO
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-09
+'  Edited:  2025-08-12
 '  Author:  ChatGPT
 '  Description: Tests for AppSettings persistence.
 '------------------------------------------------------------------------------
@@ -28,6 +28,18 @@ Public Class AppSettingsTests
         Assert.AreEqual("COM7", loaded.ComPort)
         Assert.AreEqual("PageUp", loaded.KeyMapping.RotateUp)
         Assert.AreEqual("Escape", loaded.KeyMapping.ButtonPress)
+    End Sub
+
+    <TestMethod>
+    Public Sub LoadLegacyNumericKeyMapping()
+        Dim dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+        Directory.CreateDirectory(dir)
+        Dim json = "{""Autostart"":false,""ComPort"":""Auto"",""KeyMapping"":{""RotateUp"":38,""RotateDown"":40,""ButtonPress"":13}}"
+        File.WriteAllText(Path.Combine(dir, "settings.json"), json)
+        Dim loaded = AppSettings.Load(dir)
+        Assert.AreEqual("Up", loaded.KeyMapping.RotateUp)
+        Assert.AreEqual("Down", loaded.KeyMapping.RotateDown)
+        Assert.AreEqual("Enter", loaded.KeyMapping.ButtonPress)
     End Sub
 
 End Class

--- a/EncoderLib.Tests/EncoderInputProcessorTests.vb
+++ b/EncoderLib.Tests/EncoderInputProcessorTests.vb
@@ -16,10 +16,10 @@ Public Class EncoderInputProcessorTests
 
     Private Class KeyboardMock
         Implements IKeyboardSender
-        Public ReadOnly Sent As New List(Of WindowsKey)
-        Public Sub SendKey(key As WindowsKey) Implements IKeyboardSender.SendKey
+        Public ReadOnly Sent As New List(Of IReadOnlyList(Of WindowsKey))
+        Public Sub SendKeys(keys As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
             SyncLock Sent
-                Sent.Add(key)
+                Sent.Add(keys)
             End SyncLock
         End Sub
     End Class
@@ -32,7 +32,7 @@ Public Class EncoderInputProcessorTests
         processor.Process(New EncoderMessage(0, RotationDirection.Clockwise), DateTime.UtcNow)
         processor.Process(New EncoderMessage(1, RotationDirection.Clockwise), DateTime.UtcNow)
         Assert.AreEqual(1, keyboard.Sent.Count)
-        Assert.AreEqual(WindowsKey.Up, keyboard.Sent(0))
+        Assert.AreEqual(WindowsKey.Up, keyboard.Sent(0)(0))
     End Sub
 
     <TestMethod>
@@ -44,7 +44,7 @@ Public Class EncoderInputProcessorTests
         processor.Process(New ButtonMessage(), now)
         processor.Process(New EncoderMessage(0, RotationDirection.Clockwise), now.AddMilliseconds(10))
         processor.Process(New EncoderMessage(1, RotationDirection.Clockwise), now.AddMilliseconds(20))
-        Assert.AreEqual(WindowsKey.PageUp, keyboard.Sent.Last())
+        Assert.AreEqual(WindowsKey.PageUp, keyboard.Sent.Last()(0))
     End Sub
 
     <TestMethod>
@@ -55,7 +55,7 @@ Public Class EncoderInputProcessorTests
         processor.Process(New ButtonMessage(), DateTime.UtcNow)
         Thread.Sleep(300)
         SyncLock keyboard.Sent
-            Assert.AreEqual(WindowsKey.Enter, keyboard.Sent.Single())
+            Assert.AreEqual(WindowsKey.Enter, keyboard.Sent.Single()(0))
         End SyncLock
     End Sub
 
@@ -71,7 +71,7 @@ Public Class EncoderInputProcessorTests
         Next
         Thread.Sleep(300)
         SyncLock keyboard.Sent
-            Assert.AreEqual(WindowsKey.Escape, keyboard.Sent.Single())
+            Assert.AreEqual(WindowsKey.Escape, keyboard.Sent.Single()(0))
         End SyncLock
     End Sub
 End Class

--- a/EncoderLib.Tests/EncoderLib.Tests.vbproj
+++ b/EncoderLib.Tests/EncoderLib.Tests.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>EncoderLib.Tests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/EncoderLib.Tests/EncoderLib.Tests.vbproj
+++ b/EncoderLib.Tests/EncoderLib.Tests.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>EncoderLib.Tests</RootNamespace>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/EncoderLib.Tests/EncoderLib.Tests.vbproj
+++ b/EncoderLib.Tests/EncoderLib.Tests.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>EncoderLib.Tests</RootNamespace>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/EncoderLib.Tests/KeyCombinationParserTests.vb
+++ b/EncoderLib.Tests/KeyCombinationParserTests.vb
@@ -1,0 +1,19 @@
+Imports EncoderLib
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+'------------------------------------------------------------------------------
+'  Created: 2025-08-12
+'  Edited:  2025-08-12
+'  Author:  ChatGPT
+'  Description: Tests for KeyCombinationParser.
+'------------------------------------------------------------------------------
+<TestClass>
+Public Class KeyCombinationParserTests
+    <TestMethod>
+    Public Sub ParsesCtrlA()
+        Dim keys = KeyCombinationParser.Parse("Ctrl+A")
+        Assert.AreEqual(2, keys.Count)
+        Assert.AreEqual(WindowsKey.Control, keys(0))
+        Assert.AreEqual(WindowsKey.A, keys(1))
+    End Sub
+End Class

--- a/EncoderLib/AppSettings.vb
+++ b/EncoderLib/AppSettings.vb
@@ -1,9 +1,11 @@
 Imports System.IO
 Imports System.Text.Json
+Imports System.Text.Json.Nodes
+Imports System.Linq
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-09
+'  Edited:  2025-08-12
 '  Author:  ChatGPT
 '  Description: Persists application settings locally.
 '------------------------------------------------------------------------------
@@ -16,6 +18,7 @@ Public Class AppSettings
         Dim filePath = GetPath(basePath)
         If File.Exists(filePath) Then
             Dim json = File.ReadAllText(filePath)
+            json = NormalizeKeyMapping(json)
             Return JsonSerializer.Deserialize(Of AppSettings)(json)
         End If
         Return New AppSettings()
@@ -23,7 +26,7 @@ Public Class AppSettings
 
     Public Sub Save(Optional basePath As String = Nothing)
         Dim filePath = GetPath(basePath)
-        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filePath))
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath))
         Dim json = JsonSerializer.Serialize(Me)
         File.WriteAllText(filePath, json)
     End Sub
@@ -32,5 +35,22 @@ Public Class AppSettings
         Dim dir = If(basePath, Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EncoderWpfApp"))
         Return Path.Combine(dir, "settings.json")
     End Function
-End Class
 
+    Private Shared Function NormalizeKeyMapping(json As String) As String
+        Dim node = JsonNode.Parse(json)
+        Dim mapping = node?("KeyMapping")?.AsObject()
+        If mapping IsNot Nothing Then
+            Dim keys = mapping.Select(Function(k) k.Key).ToList()
+            For Each key In keys
+                Dim valNode = TryCast(mapping(key), JsonValue)
+                If valNode IsNot Nothing Then
+                    Dim num As Integer
+                    If valNode.TryGetValue(Of Integer)(num) Then
+                        mapping(key) = CType(num, WindowsKey).ToString()
+                    End If
+                End If
+            Next
+        End If
+        Return node.ToJsonString()
+    End Function
+End Class

--- a/EncoderLib/EncoderInputProcessor.vb
+++ b/EncoderLib/EncoderInputProcessor.vb
@@ -1,4 +1,5 @@
 Imports System
+Imports System.Collections.Generic
 Imports System.Timers
 
 '------------------------------------------------------------------------------
@@ -55,14 +56,14 @@ Public Class EncoderInputProcessor
         If lastPosition.HasValue Then
             Dim stepCount = msg.Position - lastPosition.Value
             If stepCount <> 0 Then
-                Dim key As WindowsKey
+                Dim combo As IReadOnlyList(Of WindowsKey)
                 If buttonPressed Then
-                    key = If(stepCount > 0, Mapper.RotateUpWithButton, Mapper.RotateDownWithButton)
+                    combo = KeyCombinationParser.Parse(If(stepCount > 0, Mapper.RotateUpWithButton, Mapper.RotateDownWithButton))
                 Else
-                    key = If(stepCount > 0, Mapper.RotateUp, Mapper.RotateDown)
+                    combo = KeyCombinationParser.Parse(If(stepCount > 0, Mapper.RotateUp, Mapper.RotateDown))
                 End If
                 For i = 1 To Math.Abs(stepCount)
-                    keyboard.SendKey(key)
+                    keyboard.SendKeys(combo)
                 Next
             End If
         End If
@@ -73,9 +74,9 @@ Public Class EncoderInputProcessor
         If buttonPressed AndAlso timestamp - lastButtonSignal > releaseThreshold Then
             Dim duration = timestamp - buttonPressStart
             If duration >= longPressThreshold Then
-                keyboard.SendKey(Mapper.ButtonLongPress)
+                keyboard.SendKeys(KeyCombinationParser.Parse(Mapper.ButtonLongPress))
             Else
-                keyboard.SendKey(Mapper.ButtonPress)
+                keyboard.SendKeys(KeyCombinationParser.Parse(Mapper.ButtonPress))
             End If
             buttonPressed = False
         End If

--- a/EncoderLib/EncoderLib.vbproj
+++ b/EncoderLib/EncoderLib.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>EncoderLib</RootNamespace>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EncoderLib/EncoderLib.vbproj
+++ b/EncoderLib/EncoderLib.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>EncoderLib</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0-windows7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EncoderLib/EncoderLib.vbproj
+++ b/EncoderLib/EncoderLib.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>EncoderLib</RootNamespace>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EncoderLib/IKeyboardSender.vb
+++ b/EncoderLib/IKeyboardSender.vb
@@ -1,9 +1,10 @@
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-09
+'  Edited:  2025-08-12
 '  Author:  ChatGPT
 '  Description: Interface for sending keyboard input.
 '------------------------------------------------------------------------------
+Imports System.Collections.Generic
 Public Interface IKeyboardSender
-    Sub SendKey(key As WindowsKey)
+    Sub SendKeys(keys As IReadOnlyList(Of WindowsKey))
 End Interface

--- a/EncoderLib/KeyCombinationParser.vb
+++ b/EncoderLib/KeyCombinationParser.vb
@@ -1,0 +1,37 @@
+Imports System
+Imports System.Collections.Generic
+
+'------------------------------------------------------------------------------
+'  Created: 2025-08-12
+'  Edited:  2025-08-12
+'  Author:  ChatGPT
+'  Description: Parses textual key combinations into WindowsKey lists.
+'------------------------------------------------------------------------------
+Public Class KeyCombinationParser
+    Public Shared Function Parse(text As String) As IReadOnlyList(Of WindowsKey)
+        Dim keys As New List(Of WindowsKey)()
+        If String.IsNullOrWhiteSpace(text) Then Return keys
+        For Each part In text.Split("+"c)
+            Dim token = part.Trim()
+            Dim key As WindowsKey
+            If [Enum].TryParse(token, True, key) Then
+                keys.Add(key)
+            Else
+                Select Case token.ToLowerInvariant()
+                    Case "ctrl", "control"
+                        keys.Add(WindowsKey.Control)
+                    Case "shift"
+                        keys.Add(WindowsKey.Shift)
+                    Case "alt"
+                        keys.Add(WindowsKey.Alt)
+                    Case "win", "windows"
+                        keys.Add(WindowsKey.LWin)
+                    Case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"
+                        Dim numKey As WindowsKey = CType([Enum].Parse(GetType(WindowsKey), "D" & token), WindowsKey)
+                        keys.Add(numKey)
+                End Select
+            End If
+        Next
+        Return keys
+    End Function
+End Class

--- a/EncoderLib/KeyMapper.vb
+++ b/EncoderLib/KeyMapper.vb
@@ -1,15 +1,15 @@
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-09
+'  Edited:  2025-08-12
 '  Author:  ChatGPT
-'  Description: Holds configurable mapping from encoder actions to Windows keys.
+'  Description: Holds configurable mapping from encoder actions to key combinations.
 '------------------------------------------------------------------------------
 Public Class KeyMapper
-    Public Property RotateUp As WindowsKey = WindowsKey.Up
-    Public Property RotateDown As WindowsKey = WindowsKey.Down
-    Public Property RotateUpWithButton As WindowsKey = WindowsKey.PageUp
-    Public Property RotateDownWithButton As WindowsKey = WindowsKey.PageDown
-    Public Property ButtonPress As WindowsKey = WindowsKey.Enter
-    Public Property ButtonLongPress As WindowsKey = WindowsKey.Escape
+    Public Property RotateUp As String = "Up"
+    Public Property RotateDown As String = "Down"
+    Public Property RotateUpWithButton As String = "PageUp"
+    Public Property RotateDownWithButton As String = "PageDown"
+    Public Property ButtonPress As String = "Enter"
+    Public Property ButtonLongPress As String = "Escape"
 End Class
 

--- a/EncoderLib/WindowsKeyboardSender.vb
+++ b/EncoderLib/WindowsKeyboardSender.vb
@@ -1,8 +1,9 @@
 Imports System.Runtime.InteropServices
+Imports System.Collections.Generic
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-09
+'  Edited:  2025-08-12
 '  Author:  ChatGPT
 '  Description: Sends keyboard input via Win32 SendInput.
 '------------------------------------------------------------------------------
@@ -28,11 +29,16 @@ Public Class WindowsKeyboardSender
     Private Shared Function SendInput(nInputs As UInteger, inputs() As INPUT, cbSize As Integer) As UInteger
     End Function
 
-    Public Sub SendKey(key As WindowsKey) Implements IKeyboardSender.SendKey
-        Dim inputs(1) As INPUT
-        inputs(0) = CreateInput(key, False)
-        inputs(1) = CreateInput(key, True)
-        SendInput(2UI, inputs, Marshal.SizeOf(GetType(INPUT)))
+    Public Sub SendKeys(keys As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
+        If keys Is Nothing OrElse keys.Count = 0 Then Return
+        Dim list As New List(Of INPUT)()
+        For Each key In keys
+            list.Add(CreateInput(key, False))
+        Next
+        For i = keys.Count - 1 To 0 Step -1
+            list.Add(CreateInput(keys(i), True))
+        Next
+        SendInput(CUInt(list.Count), list.ToArray(), Marshal.SizeOf(GetType(INPUT)))
     End Sub
 
     Private Function CreateInput(key As WindowsKey, keyUp As Boolean) As INPUT

--- a/EncoderWpfApp/EncoderWpfApp.vbproj
+++ b/EncoderWpfApp/EncoderWpfApp.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/EncoderWpfApp/EncoderWpfApp.vbproj
+++ b/EncoderWpfApp/EncoderWpfApp.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/EncoderWpfApp/EncoderWpfApp.vbproj
+++ b/EncoderWpfApp/EncoderWpfApp.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/EncoderWpfApp/HardwareSimulatorWindow.xaml
+++ b/EncoderWpfApp/HardwareSimulatorWindow.xaml
@@ -1,0 +1,13 @@
+<Window x:Class="EncoderWpfApp.HardwareSimulatorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Simulator" Height="250" Width="200">
+    <StackPanel Margin="10">
+        <Button Content="Rotate Up" Margin="0,0,0,5" Click="RotateUp_Click" />
+        <Button Content="Rotate Down" Margin="0,0,0,5" Click="RotateDown_Click" />
+        <Button Content="Rotate Up + Button" Margin="0,0,0,5" Click="RotateUpBtn_Click" />
+        <Button Content="Rotate Down + Button" Margin="0,0,0,5" Click="RotateDownBtn_Click" />
+        <Button Content="Button Press" Margin="0,0,0,5" Click="ButtonPress_Click" />
+        <Button Content="Button Long Press" Click="ButtonLongPress_Click" />
+    </StackPanel>
+</Window>

--- a/EncoderWpfApp/HardwareSimulatorWindow.xaml.vb
+++ b/EncoderWpfApp/HardwareSimulatorWindow.xaml.vb
@@ -1,0 +1,56 @@
+Imports System.Threading.Tasks
+Imports System.Windows
+Imports EncoderLib
+
+'------------------------------------------------------------------------------
+'  Created: 2025-08-12
+'  Edited:  2025-08-12
+'  Author:  ChatGPT
+'  Description: Simulates hardware events via buttons.
+'------------------------------------------------------------------------------
+Namespace EncoderWpfApp
+    Partial Class HardwareSimulatorWindow
+        Inherits Window
+
+        Private ReadOnly processor As EncoderInputProcessor
+        Private position As Integer
+
+        Public Sub New(proc As EncoderInputProcessor)
+            InitializeComponent()
+            processor = proc
+            position = 0
+        End Sub
+
+        Private Sub RotateUp_Click(sender As Object, e As RoutedEventArgs)
+            position += 1
+            processor.Process(New EncoderMessage(position, RotationDirection.Clockwise), DateTime.UtcNow)
+        End Sub
+
+        Private Sub RotateDown_Click(sender As Object, e As RoutedEventArgs)
+            position -= 1
+            processor.Process(New EncoderMessage(position, RotationDirection.CounterClockwise), DateTime.UtcNow)
+        End Sub
+
+        Private Sub RotateUpBtn_Click(sender As Object, e As RoutedEventArgs)
+            processor.Process(New ButtonMessage(), DateTime.UtcNow)
+            RotateUp_Click(sender, e)
+        End Sub
+
+        Private Sub RotateDownBtn_Click(sender As Object, e As RoutedEventArgs)
+            processor.Process(New ButtonMessage(), DateTime.UtcNow)
+            RotateDown_Click(sender, e)
+        End Sub
+
+        Private Sub ButtonPress_Click(sender As Object, e As RoutedEventArgs)
+            processor.Process(New ButtonMessage(), DateTime.UtcNow)
+        End Sub
+
+        Private Async Sub ButtonLongPress_Click(sender As Object, e As RoutedEventArgs)
+            processor.Process(New ButtonMessage(), DateTime.UtcNow)
+            For i = 1 To 6
+                Await Task.Delay(150)
+                processor.Process(New ButtonMessage(), DateTime.UtcNow)
+            Next
+        End Sub
+    End Class
+End Namespace

--- a/EncoderWpfApp/KeyMappingWindow.xaml
+++ b/EncoderWpfApp/KeyMappingWindow.xaml
@@ -18,22 +18,22 @@
         </Grid.ColumnDefinitions>
 
         <TextBlock Text="Rotate Up:" Grid.Row="0" Grid.Column="0" Margin="0,0,5,5" />
-        <ComboBox x:Name="RotateUpBox" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" />
+        <ComboBox x:Name="RotateUpBox" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" IsEditable="True" />
 
         <TextBlock Text="Rotate Down:" Grid.Row="1" Grid.Column="0" Margin="0,0,5,5" />
-        <ComboBox x:Name="RotateDownBox" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" />
+        <ComboBox x:Name="RotateDownBox" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" IsEditable="True" />
 
         <TextBlock Text="Rotate Up + Button:" Grid.Row="2" Grid.Column="0" Margin="0,0,5,5" />
-        <ComboBox x:Name="RotateUpBtnBox" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" />
+        <ComboBox x:Name="RotateUpBtnBox" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" IsEditable="True" />
 
         <TextBlock Text="Rotate Down + Button:" Grid.Row="3" Grid.Column="0" Margin="0,0,5,5" />
-        <ComboBox x:Name="RotateDownBtnBox" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5" />
+        <ComboBox x:Name="RotateDownBtnBox" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5" IsEditable="True" />
 
         <TextBlock Text="Button Press:" Grid.Row="4" Grid.Column="0" Margin="0,0,5,5" />
-        <ComboBox x:Name="ButtonPressBox" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5" />
+        <ComboBox x:Name="ButtonPressBox" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5" IsEditable="True" />
 
         <TextBlock Text="Button Long Press:" Grid.Row="5" Grid.Column="0" Margin="0,0,5,5" />
-        <ComboBox x:Name="ButtonLongPressBox" Grid.Row="5" Grid.Column="1" Margin="0,0,0,5" />
+        <ComboBox x:Name="ButtonLongPressBox" Grid.Row="5" Grid.Column="1" Margin="0,0,0,5" IsEditable="True" />
 
         <StackPanel Orientation="Horizontal" Grid.Row="6" Grid.ColumnSpan="2" HorizontalAlignment="Right">
             <Button Content="OK" Width="60" Margin="0,10,5,0" Click="Ok_Click" />

--- a/EncoderWpfApp/KeyMappingWindow.xaml.vb
+++ b/EncoderWpfApp/KeyMappingWindow.xaml.vb
@@ -16,7 +16,7 @@ Namespace EncoderWpfApp
         Public Sub New(mapping As KeyMapper)
             InitializeComponent()
             Me.mapping = mapping
-            Dim values = [Enum].GetValues(GetType(WindowsKey))
+            Dim values = [Enum].GetNames(GetType(WindowsKey))
             RotateUpBox.ItemsSource = values
             RotateDownBox.ItemsSource = values
             RotateUpBtnBox.ItemsSource = values
@@ -24,21 +24,21 @@ Namespace EncoderWpfApp
             ButtonPressBox.ItemsSource = values
             ButtonLongPressBox.ItemsSource = values
 
-            RotateUpBox.SelectedItem = mapping.RotateUp
-            RotateDownBox.SelectedItem = mapping.RotateDown
-            RotateUpBtnBox.SelectedItem = mapping.RotateUpWithButton
-            RotateDownBtnBox.SelectedItem = mapping.RotateDownWithButton
-            ButtonPressBox.SelectedItem = mapping.ButtonPress
-            ButtonLongPressBox.SelectedItem = mapping.ButtonLongPress
+            RotateUpBox.Text = mapping.RotateUp
+            RotateDownBox.Text = mapping.RotateDown
+            RotateUpBtnBox.Text = mapping.RotateUpWithButton
+            RotateDownBtnBox.Text = mapping.RotateDownWithButton
+            ButtonPressBox.Text = mapping.ButtonPress
+            ButtonLongPressBox.Text = mapping.ButtonLongPress
         End Sub
 
         Private Sub Ok_Click(sender As Object, e As RoutedEventArgs)
-            mapping.RotateUp = CType(RotateUpBox.SelectedItem, WindowsKey)
-            mapping.RotateDown = CType(RotateDownBox.SelectedItem, WindowsKey)
-            mapping.RotateUpWithButton = CType(RotateUpBtnBox.SelectedItem, WindowsKey)
-            mapping.RotateDownWithButton = CType(RotateDownBtnBox.SelectedItem, WindowsKey)
-            mapping.ButtonPress = CType(ButtonPressBox.SelectedItem, WindowsKey)
-            mapping.ButtonLongPress = CType(ButtonLongPressBox.SelectedItem, WindowsKey)
+            mapping.RotateUp = RotateUpBox.Text
+            mapping.RotateDown = RotateDownBox.Text
+            mapping.RotateUpWithButton = RotateUpBtnBox.Text
+            mapping.RotateDownWithButton = RotateDownBtnBox.Text
+            mapping.ButtonPress = ButtonPressBox.Text
+            mapping.ButtonLongPress = ButtonLongPressBox.Text
             DialogResult = True
         End Sub
     End Class

--- a/EncoderWpfApp/MainWindow.xaml
+++ b/EncoderWpfApp/MainWindow.xaml
@@ -8,6 +8,7 @@
                 <MenuItem x:Name="AutostartMenuItem" Header="_Autostart" IsCheckable="True" />
                 <MenuItem x:Name="ComPortMenuItem" Header="_COM-Port" />
                 <MenuItem x:Name="KeyMappingMenuItem" Header="_Key Mapping" />
+                <MenuItem x:Name="SimulatorMenuItem" Header="_Simulator" />
             </MenuItem>
         </Menu>
         <StackPanel Margin="10">

--- a/EncoderWpfApp/MainWindow.xaml.vb
+++ b/EncoderWpfApp/MainWindow.xaml.vb
@@ -8,6 +8,7 @@ Imports System.Windows
 Imports System.Windows.Controls
 Imports System.Windows.Threading
 Imports EncoderLib
+Imports System.Collections.Generic
 
 Namespace EncoderWpfApp
 
@@ -28,7 +29,7 @@ Namespace EncoderWpfApp
             autoStart = New AutoStartManager("EncoderWpfApp", settings)
             AutostartMenuItem.IsChecked = autoStart.IsEnabled()
             keyboard = New NotifyingKeyboardSender(New WindowsKeyboardSender())
-            AddHandler keyboard.KeySent, AddressOf OnKeySent
+            AddHandler keyboard.KeysSent, AddressOf OnKeysSent
             processor = New EncoderInputProcessor(keyboard)
             processor.Mapper = settings.KeyMapping
             controller = New CommPortController(AddressOf HandleLine)
@@ -56,8 +57,8 @@ Namespace EncoderWpfApp
                                End Sub)
         End Sub
 
-        Private Sub OnKeySent(key As WindowsKey)
-            KeyText.Text = $"Last key: {key}"
+        Private Sub OnKeysSent(keys As IReadOnlyList(Of WindowsKey))
+            KeyText.Text = $"Last key: {String.Join(" + ", keys)}"
         End Sub
 
         Private Sub AutostartMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles AutostartMenuItem.Click
@@ -132,6 +133,11 @@ Namespace EncoderWpfApp
                 settings.Save()
                 processor.Mapper = settings.KeyMapping
             End If
+        End Sub
+
+        Private Sub SimulatorMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles SimulatorMenuItem.Click
+            Dim sim As New HardwareSimulatorWindow(processor)
+            sim.Show()
         End Sub
     End Class
 End Namespace

--- a/EncoderWpfApp/NotifyingKeyboardSender.vb
+++ b/EncoderWpfApp/NotifyingKeyboardSender.vb
@@ -1,8 +1,9 @@
 Imports EncoderLib
+Imports System.Collections.Generic
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-09
+'  Edited:  2025-08-12
 '  Author:  ChatGPT
 '  Description: Wraps keyboard sender and exposes sent keys.
 '------------------------------------------------------------------------------
@@ -10,15 +11,15 @@ Public Class NotifyingKeyboardSender
     Implements IKeyboardSender
 
     Private ReadOnly inner As IKeyboardSender
-    Public Event KeySent(key As WindowsKey)
+    Public Event KeysSent(keys As IReadOnlyList(Of WindowsKey))
 
     Public Sub New(inner As IKeyboardSender)
         Me.inner = inner
     End Sub
 
-    Public Sub SendKey(key As WindowsKey) Implements IKeyboardSender.SendKey
-        inner.SendKey(key)
-        RaiseEvent KeySent(key)
+    Public Sub SendKeys(keys As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
+        inner.SendKeys(keys)
+        RaiseEvent KeysSent(keys)
     End Sub
 End Class
 


### PR DESCRIPTION
## Summary
- allow free-text key combinations in mapping and parse them for SendInput
- extend keyboard sender to handle multiple keys and surface sent combinations
- add WPF hardware simulator window for testing without COM

## Testing
- `dotnet test EncoderLib.Tests/EncoderLib.Tests.vbproj`

------
https://chatgpt.com/codex/tasks/task_e_689ad945b88c8333894f3c6687ef805c