### PR TITLE
Add simulator run-all button and dynamic version

### DIFF
--- a/EncoderWpfApp.Tests/HardwareSimulatorWindowTests.vb
+++ b/EncoderWpfApp.Tests/HardwareSimulatorWindowTests.vb
@@ -1,6 +1,6 @@
 '------------------------------------------------------------------------------
 '  Created: 2025-08-12
-'  Edited:  2025-08-12
+'  Edited:  2025-08-14
 '  Author:  ChatGPT
 '  Description: Tests for hardware simulator run-all button.
 '------------------------------------------------------------------------------
@@ -15,7 +15,7 @@ Public Class HardwareSimulatorWindowTests
     Public Async Function ClickAllButtonsAsync_SendsExpectedSequences() As Task
         Dim recorder As New RecordingKeyboardSender()
         Dim processor As New EncoderInputProcessor(recorder)
-        Dim window As New EncoderWpfApp.HardwareSimulatorWindow(processor, Function(ts) Task.CompletedTask)
+        Dim window As New Global.EncoderWpfApp.HardwareSimulatorWindow(processor, Function(ts) Task.CompletedTask)
 
         Await window.ClickAllButtonsAsync()
         Await Task.Delay(300)

--- a/EncoderWpfApp.Tests/HardwareSimulatorWindowTests.vb
+++ b/EncoderWpfApp.Tests/HardwareSimulatorWindowTests.vb
@@ -8,7 +8,6 @@ Imports System.Collections.Generic
 Imports System.Threading.Tasks
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports EncoderLib
-Imports EncoderWpfApp
 
 <TestClass>
 Public Class HardwareSimulatorWindowTests
@@ -16,23 +15,23 @@ Public Class HardwareSimulatorWindowTests
     Public Async Function ClickAllButtonsAsync_SendsExpectedSequences() As Task
         Dim recorder As New RecordingKeyboardSender()
         Dim processor As New EncoderInputProcessor(recorder)
-        Dim window As New HardwareSimulatorWindow(processor, Function(ts) Task.CompletedTask)
+        Dim window As New EncoderWpfApp.HardwareSimulatorWindow(processor, Function(ts) Task.CompletedTask)
 
         Await window.ClickAllButtonsAsync()
         Await Task.Delay(300)
 
         Dim expected = {"Up", "Down", "PageUp", "PageDown", "Escape"}
-        Dim actual = recorder.Keys.ConvertAll(Function(k) String.Join("+", k)).ToArray()
+        Dim actual = recorder.SentKeySequences.ConvertAll(Function(k) String.Join("+", k)).ToArray()
         CollectionAssert.AreEqual(expected, actual)
     End Function
 
     Private Class RecordingKeyboardSender
         Implements IKeyboardSender
 
-        Public ReadOnly Keys As New List(Of IReadOnlyList(Of WindowsKey))()
+        Public ReadOnly SentKeySequences As New List(Of IReadOnlyList(Of WindowsKey))()
 
-        Public Sub SendKeys(keys As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
-            Keys.Add(keys)
+        Public Sub SendKeys(keySequence As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
+            Me.SentKeySequences.Add(keySequence)
         End Sub
     End Class
 End Class

--- a/EncoderWpfApp.Tests/HardwareSimulatorWindowTests.vb
+++ b/EncoderWpfApp.Tests/HardwareSimulatorWindowTests.vb
@@ -1,0 +1,38 @@
+'------------------------------------------------------------------------------
+'  Created: 2025-08-12
+'  Edited:  2025-08-12
+'  Author:  ChatGPT
+'  Description: Tests for hardware simulator run-all button.
+'------------------------------------------------------------------------------
+Imports System.Collections.Generic
+Imports System.Threading.Tasks
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+Imports EncoderLib
+Imports EncoderWpfApp
+
+<TestClass>
+Public Class HardwareSimulatorWindowTests
+    <TestMethod>
+    Public Async Function ClickAllButtonsAsync_SendsExpectedSequences() As Task
+        Dim recorder As New RecordingKeyboardSender()
+        Dim processor As New EncoderInputProcessor(recorder)
+        Dim window As New HardwareSimulatorWindow(processor, Function(ts) Task.CompletedTask)
+
+        Await window.ClickAllButtonsAsync()
+        Await Task.Delay(300)
+
+        Dim expected = {"Up", "Down", "PageUp", "PageDown", "Escape"}
+        Dim actual = recorder.Keys.ConvertAll(Function(k) String.Join("+", k)).ToArray()
+        CollectionAssert.AreEqual(expected, actual)
+    End Function
+
+    Private Class RecordingKeyboardSender
+        Implements IKeyboardSender
+
+        Public ReadOnly Keys As New List(Of IReadOnlyList(Of WindowsKey))()
+
+        Public Sub SendKeys(keys As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
+            Keys.Add(keys)
+        End Sub
+    End Class
+End Class

--- a/EncoderWpfApp/Application.xaml
+++ b/EncoderWpfApp/Application.xaml
@@ -1,5 +1,5 @@
 <!-- App.xaml -->
-<Application x:Class="EncoderWpfApp.App"
+<Application x:Class="App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml"

--- a/EncoderWpfApp/HardwareSimulatorWindow.xaml
+++ b/EncoderWpfApp/HardwareSimulatorWindow.xaml
@@ -9,5 +9,6 @@
         <Button Content="Rotate Down + Button" Margin="0,0,0,5" Click="RotateDownBtn_Click" />
         <Button Content="Button Press" Margin="0,0,0,5" Click="ButtonPress_Click" />
         <Button Content="Button Long Press" Click="ButtonLongPress_Click" />
+        <Button Content="Run All" Margin="0,10,0,0" Click="RunAllButtons_Click" />
     </StackPanel>
 </Window>

--- a/EncoderWpfApp/HardwareSimulatorWindow.xaml
+++ b/EncoderWpfApp/HardwareSimulatorWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="EncoderWpfApp.HardwareSimulatorWindow"
+<Window x:Class="HardwareSimulatorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Simulator" Height="250" Width="200" Icon="/HomeCockpit_Icon_DEFAULT.png">

--- a/EncoderWpfApp/HardwareSimulatorWindow.xaml.vb
+++ b/EncoderWpfApp/HardwareSimulatorWindow.xaml.vb
@@ -1,16 +1,17 @@
 Imports System
 Imports System.Threading.Tasks
 Imports System.Windows
+Imports System.Windows.Controls
 Imports EncoderLib
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-12
-'  Edited:  2025-08-12
+'  Edited:  2025-08-14
 '  Author:  ChatGPT
 '  Description: Simulates hardware events via buttons.
 '------------------------------------------------------------------------------
 Namespace EncoderWpfApp
-    Partial Class HardwareSimulatorWindow
+    Public Partial Class HardwareSimulatorWindow
         Inherits Window
 
         Private ReadOnly processor As EncoderInputProcessor
@@ -76,7 +77,13 @@ Namespace EncoderWpfApp
         End Function
 
         Private Async Sub RunAllButtons_Click(sender As Object, e As RoutedEventArgs)
-            Await ClickAllButtonsAsync()
+            Dim btn = CType(sender, Button)
+            btn.IsEnabled = False
+            Try
+                Await ClickAllButtonsAsync()
+            Finally
+                btn.IsEnabled = True
+            End Try
         End Sub
     End Class
 End Namespace

--- a/EncoderWpfApp/HardwareSimulatorWindow.xaml.vb
+++ b/EncoderWpfApp/HardwareSimulatorWindow.xaml.vb
@@ -10,80 +10,79 @@ Imports EncoderLib
 '  Author:  ChatGPT
 '  Description: Simulates hardware events via buttons.
 '------------------------------------------------------------------------------
-Namespace EncoderWpfApp
-    Public Partial Class HardwareSimulatorWindow
-        Inherits Window
+Public Partial Class HardwareSimulatorWindow
+    Inherits Window
 
-        Private ReadOnly processor As EncoderInputProcessor
-        Private ReadOnly delayProvider As Func(Of TimeSpan, Task)
-        Private position As Integer
+    Private ReadOnly processor As EncoderInputProcessor
+    Private ReadOnly delayProvider As Func(Of TimeSpan, Task)
+    Private position As Integer
 
-        Public Sub New(proc As EncoderInputProcessor, Optional delayProvider As Func(Of TimeSpan, Task) = Nothing)
-            InitializeComponent()
-            processor = proc
-            Me.delayProvider = If(delayProvider, Function(ts) Task.Delay(ts))
-            position = 0
-        End Sub
+    Public Sub New(proc As EncoderInputProcessor, Optional delayProvider As Func(Of TimeSpan, Task) = Nothing)
+        InitializeComponent()
+        processor = proc
+        Me.delayProvider = If(delayProvider, Function(ts) Task.Delay(ts))
+        position = 0
+    End Sub
 
-        Private Sub RotateUp_Click(sender As Object, e As RoutedEventArgs)
-            position += 1
-            processor.Process(New EncoderMessage(position, RotationDirection.Clockwise), DateTime.UtcNow)
-        End Sub
+    Private Sub RotateUp_Click(sender As Object, e As RoutedEventArgs)
+        position += 1
+        processor.Process(New EncoderMessage(position, RotationDirection.Clockwise), DateTime.UtcNow)
+    End Sub
 
-        Private Sub RotateDown_Click(sender As Object, e As RoutedEventArgs)
-            position -= 1
-            processor.Process(New EncoderMessage(position, RotationDirection.CounterClockwise), DateTime.UtcNow)
-        End Sub
+    Private Sub RotateDown_Click(sender As Object, e As RoutedEventArgs)
+        position -= 1
+        processor.Process(New EncoderMessage(position, RotationDirection.CounterClockwise), DateTime.UtcNow)
+    End Sub
 
-        Private Sub RotateUpBtn_Click(sender As Object, e As RoutedEventArgs)
+    Private Sub RotateUpBtn_Click(sender As Object, e As RoutedEventArgs)
+        processor.Process(New ButtonMessage(), DateTime.UtcNow)
+        RotateUp_Click(sender, e)
+    End Sub
+
+    Private Sub RotateDownBtn_Click(sender As Object, e As RoutedEventArgs)
+        processor.Process(New ButtonMessage(), DateTime.UtcNow)
+        RotateDown_Click(sender, e)
+    End Sub
+
+    Private Sub ButtonPress_Click(sender As Object, e As RoutedEventArgs)
+        processor.Process(New ButtonMessage(), DateTime.UtcNow)
+    End Sub
+
+    Private Async Function PerformButtonLongPressAsync() As Task
+        processor.Process(New ButtonMessage(), DateTime.UtcNow)
+        For i = 1 To 6
+            Await delayProvider(TimeSpan.FromMilliseconds(150))
             processor.Process(New ButtonMessage(), DateTime.UtcNow)
-            RotateUp_Click(sender, e)
-        End Sub
+        Next
+    End Function
 
-        Private Sub RotateDownBtn_Click(sender As Object, e As RoutedEventArgs)
-            processor.Process(New ButtonMessage(), DateTime.UtcNow)
-            RotateDown_Click(sender, e)
-        End Sub
+    Private Async Sub ButtonLongPress_Click(sender As Object, e As RoutedEventArgs)
+        Await PerformButtonLongPressAsync()
+    End Sub
 
-        Private Sub ButtonPress_Click(sender As Object, e As RoutedEventArgs)
-            processor.Process(New ButtonMessage(), DateTime.UtcNow)
-        End Sub
+    Public Async Function ClickAllButtonsAsync() As Task
+        Await delayProvider(TimeSpan.FromSeconds(1))
+        RotateUp_Click(Me, New RoutedEventArgs())
+        Await delayProvider(TimeSpan.FromSeconds(1))
+        RotateDown_Click(Me, New RoutedEventArgs())
+        Await delayProvider(TimeSpan.FromSeconds(1))
+        RotateUpBtn_Click(Me, New RoutedEventArgs())
+        Await delayProvider(TimeSpan.FromSeconds(1))
+        RotateDownBtn_Click(Me, New RoutedEventArgs())
+        Await delayProvider(TimeSpan.FromSeconds(1))
+        ButtonPress_Click(Me, New RoutedEventArgs())
+        Await delayProvider(TimeSpan.FromSeconds(1))
+        Await PerformButtonLongPressAsync()
+    End Function
 
-        Private Async Function PerformButtonLongPressAsync() As Task
-            processor.Process(New ButtonMessage(), DateTime.UtcNow)
-            For i = 1 To 6
-                Await delayProvider(TimeSpan.FromMilliseconds(150))
-                processor.Process(New ButtonMessage(), DateTime.UtcNow)
-            Next
-        End Function
+    Private Async Sub RunAllButtons_Click(sender As Object, e As RoutedEventArgs)
+        Dim btn = CType(sender, Button)
+        btn.IsEnabled = False
+        Try
+            Await ClickAllButtonsAsync()
+        Finally
+            btn.IsEnabled = True
+        End Try
+    End Sub
+End Class
 
-        Private Async Sub ButtonLongPress_Click(sender As Object, e As RoutedEventArgs)
-            Await PerformButtonLongPressAsync()
-        End Sub
-
-        Public Async Function ClickAllButtonsAsync() As Task
-            Await delayProvider(TimeSpan.FromSeconds(1))
-            RotateUp_Click(Me, New RoutedEventArgs())
-            Await delayProvider(TimeSpan.FromSeconds(1))
-            RotateDown_Click(Me, New RoutedEventArgs())
-            Await delayProvider(TimeSpan.FromSeconds(1))
-            RotateUpBtn_Click(Me, New RoutedEventArgs())
-            Await delayProvider(TimeSpan.FromSeconds(1))
-            RotateDownBtn_Click(Me, New RoutedEventArgs())
-            Await delayProvider(TimeSpan.FromSeconds(1))
-            ButtonPress_Click(Me, New RoutedEventArgs())
-            Await delayProvider(TimeSpan.FromSeconds(1))
-            Await PerformButtonLongPressAsync()
-        End Function
-
-        Private Async Sub RunAllButtons_Click(sender As Object, e As RoutedEventArgs)
-            Dim btn = CType(sender, Button)
-            btn.IsEnabled = False
-            Try
-                Await ClickAllButtonsAsync()
-            Finally
-                btn.IsEnabled = True
-            End Try
-        End Sub
-    End Class
-End Namespace

--- a/EncoderWpfApp/KeyMappingWindow.xaml
+++ b/EncoderWpfApp/KeyMappingWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="EncoderWpfApp.KeyMappingWindow"
+<Window x:Class="KeyMappingWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Key Mapping" Height="300" Width="350">

--- a/EncoderWpfApp/KeyMappingWindow.xaml.vb
+++ b/EncoderWpfApp/KeyMappingWindow.xaml.vb
@@ -3,44 +3,42 @@ Imports EncoderLib
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-09
+'  Edited:  2025-08-14
 '  Author:  ChatGPT
 '  Description: Window allowing configuration of key mapping.
 '------------------------------------------------------------------------------
-Namespace EncoderWpfApp
-    Partial Class KeyMappingWindow
-        Inherits Window
+Partial Class KeyMappingWindow
+    Inherits Window
 
-        Private ReadOnly mapping As KeyMapper
+    Private ReadOnly mapping As KeyMapper
 
-        Public Sub New(mapping As KeyMapper)
-            InitializeComponent()
-            Me.mapping = mapping
-            Dim values = [Enum].GetNames(GetType(WindowsKey))
-            RotateUpBox.ItemsSource = values
-            RotateDownBox.ItemsSource = values
-            RotateUpBtnBox.ItemsSource = values
-            RotateDownBtnBox.ItemsSource = values
-            ButtonPressBox.ItemsSource = values
-            ButtonLongPressBox.ItemsSource = values
+    Public Sub New(mapping As KeyMapper)
+        InitializeComponent()
+        Me.mapping = mapping
+        Dim values = [Enum].GetNames(GetType(WindowsKey))
+        RotateUpBox.ItemsSource = values
+        RotateDownBox.ItemsSource = values
+        RotateUpBtnBox.ItemsSource = values
+        RotateDownBtnBox.ItemsSource = values
+        ButtonPressBox.ItemsSource = values
+        ButtonLongPressBox.ItemsSource = values
 
-            RotateUpBox.Text = mapping.RotateUp
-            RotateDownBox.Text = mapping.RotateDown
-            RotateUpBtnBox.Text = mapping.RotateUpWithButton
-            RotateDownBtnBox.Text = mapping.RotateDownWithButton
-            ButtonPressBox.Text = mapping.ButtonPress
-            ButtonLongPressBox.Text = mapping.ButtonLongPress
-        End Sub
+        RotateUpBox.Text = mapping.RotateUp
+        RotateDownBox.Text = mapping.RotateDown
+        RotateUpBtnBox.Text = mapping.RotateUpWithButton
+        RotateDownBtnBox.Text = mapping.RotateDownWithButton
+        ButtonPressBox.Text = mapping.ButtonPress
+        ButtonLongPressBox.Text = mapping.ButtonLongPress
+    End Sub
 
-        Private Sub Ok_Click(sender As Object, e As RoutedEventArgs)
-            mapping.RotateUp = RotateUpBox.Text
-            mapping.RotateDown = RotateDownBox.Text
-            mapping.RotateUpWithButton = RotateUpBtnBox.Text
-            mapping.RotateDownWithButton = RotateDownBtnBox.Text
-            mapping.ButtonPress = ButtonPressBox.Text
-            mapping.ButtonLongPress = ButtonLongPressBox.Text
-            DialogResult = True
-        End Sub
-    End Class
-End Namespace
+    Private Sub Ok_Click(sender As Object, e As RoutedEventArgs)
+        mapping.RotateUp = RotateUpBox.Text
+        mapping.RotateDown = RotateDownBox.Text
+        mapping.RotateUpWithButton = RotateUpBtnBox.Text
+        mapping.RotateDownWithButton = RotateDownBtnBox.Text
+        mapping.ButtonPress = ButtonPressBox.Text
+        mapping.ButtonLongPress = ButtonLongPressBox.Text
+        DialogResult = True
+    End Sub
+End Class
 

--- a/EncoderWpfApp/MainWindow.xaml
+++ b/EncoderWpfApp/MainWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="EncoderWpfApp.MainWindow"
+<Window x:Class="MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="HomeCockpit  - Jonas Lang / Timo Boehme"

--- a/EncoderWpfApp/MainWindow.xaml
+++ b/EncoderWpfApp/MainWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="EncoderWpfApp.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="HomeCockpit  - Jonas Lang / Timo Boehme - V1.0.0.0" 
+        Title="HomeCockpit  - Jonas Lang / Timo Boehme"
         Height="200" 
         Width="320" 
         Icon="/HomeCockpit_Icon_DEFAULT.png">

--- a/EncoderWpfApp/MainWindow.xaml.vb
+++ b/EncoderWpfApp/MainWindow.xaml.vb
@@ -9,6 +9,7 @@ Imports System.Windows.Controls
 Imports System.Windows.Threading
 Imports EncoderLib
 Imports System.Collections.Generic
+Imports System.Diagnostics
 
 Namespace EncoderWpfApp
 
@@ -25,9 +26,10 @@ Namespace EncoderWpfApp
 
         Public Sub New()
             InitializeComponent()
-            Dim appVersion = My.Application.Info.Version.ToString()
-            Me.Title = $"HomeCockpit  - Jonas Lang / Timo Boehme - V{appVersion}"
-            VersionText.Text = $"Version: {appVersion}"
+            Dim assembly = System.Reflection.Assembly.GetExecutingAssembly()
+            Dim fileVersion = FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion
+            Me.Title = $"HomeCockpit  - Jonas Lang / Timo Boehme - V{fileVersion}"
+            VersionText.Text = $"Version: {fileVersion}"
             settings = AppSettings.Load()
             autoStart = New AutoStartManager("EncoderWpfApp", settings)
             AutostartMenuItem.IsChecked = autoStart.IsEnabled()

--- a/EncoderWpfApp/MainWindow.xaml.vb
+++ b/EncoderWpfApp/MainWindow.xaml.vb
@@ -1,6 +1,6 @@
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-12
+'  Edited:  2025-08-14
 '  Author:  ChatGPT
 '  Description: Main window showing connection info and autostart.
 '------------------------------------------------------------------------------
@@ -11,147 +11,144 @@ Imports EncoderLib
 Imports System.Collections.Generic
 Imports System.Diagnostics
 
-Namespace EncoderWpfApp
+Partial Class MainWindow
+    Inherits Window
 
-    Partial Class MainWindow
-        Inherits Window
+    Private controller As CommPortController
+    Private ReadOnly parser As New ProtocolParser()
+    Private processor As EncoderInputProcessor
+    Private keyboard As NotifyingKeyboardSender
+    Private settings As AppSettings
+    Private autoStart As AutoStartManager
+    Private tray As TrayIconManager
 
-        Private controller As CommPortController
-        Private ReadOnly parser As New ProtocolParser()
-        Private processor As EncoderInputProcessor
-        Private keyboard As NotifyingKeyboardSender
-        Private settings As AppSettings
-        Private autoStart As AutoStartManager
-        Private tray As TrayIconManager
+    Public Sub New()
+        InitializeComponent()
+        Dim assembly = System.Reflection.Assembly.GetExecutingAssembly()
+        Dim fileVersion = FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion
+        Me.Title = $"HomeCockpit  - Jonas Lang / Timo Boehme - V{fileVersion}"
+        VersionText.Text = $"Version: {fileVersion}"
+        settings = AppSettings.Load()
+        autoStart = New AutoStartManager("EncoderWpfApp", settings)
+        AutostartMenuItem.IsChecked = autoStart.IsEnabled()
+        keyboard = New NotifyingKeyboardSender(New WindowsKeyboardSender())
+        AddHandler keyboard.KeysSent, AddressOf OnKeysSent
+        processor = New EncoderInputProcessor(keyboard)
+        processor.Mapper = settings.KeyMapping
+        controller = New CommPortController(AddressOf HandleLine)
+        AddHandler controller.Disconnected, AddressOf OnControllerDisconnected
+        PopulateComPorts()
+        ConnectPort()
+        tray = New TrayIconManager(Me)
+        tray.Show()
+        AddHandler Me.StateChanged, AddressOf OnStateChanged
+        AddHandler Me.Closed, Sub() tray.Dispose()
+        If Environment.GetCommandLineArgs().Contains("--autostart") Then
+            Me.Hide()
+        End If
+    End Sub
 
-        Public Sub New()
-            InitializeComponent()
-            Dim assembly = System.Reflection.Assembly.GetExecutingAssembly()
-            Dim fileVersion = FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion
-            Me.Title = $"HomeCockpit  - Jonas Lang / Timo Boehme - V{fileVersion}"
-            VersionText.Text = $"Version: {fileVersion}"
-            settings = AppSettings.Load()
-            autoStart = New AutoStartManager("EncoderWpfApp", settings)
-            AutostartMenuItem.IsChecked = autoStart.IsEnabled()
-            keyboard = New NotifyingKeyboardSender(New WindowsKeyboardSender())
-            AddHandler keyboard.KeysSent, AddressOf OnKeysSent
-            processor = New EncoderInputProcessor(keyboard)
-            processor.Mapper = settings.KeyMapping
-            controller = New CommPortController(AddressOf HandleLine)
-            AddHandler controller.Disconnected, AddressOf OnControllerDisconnected
-            PopulateComPorts()
-            ConnectPort()
-            tray = New TrayIconManager(Me)
-            tray.Show()
-            AddHandler Me.StateChanged, AddressOf OnStateChanged
-            AddHandler Me.Closed, Sub() tray.Dispose()
-            If Environment.GetCommandLineArgs().Contains("--autostart") Then
-                Me.Hide()
-            End If
-        End Sub
+    Private Sub HandleLine(line As String)
+        Dim msg As HardwareMessage = Nothing
+        Dim isVersion = line.StartsWith("Version:", StringComparison.OrdinalIgnoreCase)
+        Dim parsed = parser.TryParse(line, msg)
+        Dispatcher.Invoke(Sub()
+                               LastMessageText.Text = line
+                               If isVersion Then
+                                   VersionText.Text = line.Trim()
+                               ElseIf parsed Then
+                                   processor.Process(msg, Date.Now)
+                               End If
+                           End Sub)
+    End Sub
 
-        Private Sub HandleLine(line As String)
-            Dim msg As HardwareMessage = Nothing
-            Dim isVersion = line.StartsWith("Version:", StringComparison.OrdinalIgnoreCase)
-            Dim parsed = parser.TryParse(line, msg)
-            Dispatcher.Invoke(Sub()
-                                   LastMessageText.Text = line
-                                   If isVersion Then
-                                       VersionText.Text = line.Trim()
-                                   ElseIf parsed Then
-                                       processor.Process(msg, Date.Now)
-                                   End If
-                               End Sub)
-        End Sub
+    Private Sub OnKeysSent(keys As IReadOnlyList(Of WindowsKey))
+        KeyText.Text = $"Last key: {String.Join(" + ", keys)}"
+        tray.IndicateKeyPress()
+    End Sub
 
-        Private Sub OnKeysSent(keys As IReadOnlyList(Of WindowsKey))
-            KeyText.Text = $"Last key: {String.Join(" + ", keys)}"
-            tray.IndicateKeyPress()
-        End Sub
+    Private Sub AutostartMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles AutostartMenuItem.Click
+        If AutostartMenuItem.IsChecked Then
+            autoStart.Enable()
+        Else
+            autoStart.Disable()
+        End If
+    End Sub
 
-        Private Sub AutostartMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles AutostartMenuItem.Click
-            If AutostartMenuItem.IsChecked Then
-                autoStart.Enable()
+    Private Sub PopulateComPorts()
+        ComPortMenuItem.Items.Clear()
+        Dim autoItem = New MenuItem() With {.Header = "_Auto", .IsCheckable = True, .IsChecked = settings.ComPort = "Auto"}
+        AddHandler autoItem.Click, Sub() SetComPort("Auto")
+        ComPortMenuItem.Items.Add(autoItem)
+        For Each port In System.IO.Ports.SerialPort.GetPortNames()
+            Dim item = New MenuItem() With {.Header = port, .IsCheckable = True, .IsChecked = settings.ComPort = port}
+            AddHandler item.Click, Sub() SetComPort(port)
+            ComPortMenuItem.Items.Add(item)
+        Next
+    End Sub
+
+    Private Sub SetComPort(port As String)
+        settings.ComPort = port
+        settings.Save()
+        PopulateComPorts()
+        ConnectPort()
+    End Sub
+
+    Private reconnectTimer As DispatcherTimer
+
+    Private Sub ConnectPort()
+        If controller.Connect(settings.ComPort) Then
+            ConnectionText.Text = $"Connected to {controller.CurrentPort}"
+            StopReconnect()
+        Else
+            If String.IsNullOrWhiteSpace(controller.LastError) Then
+                ConnectionText.Text = "Disconnected"
             Else
-                autoStart.Disable()
+                ConnectionText.Text = $"Error: {controller.LastError}"
             End If
-        End Sub
+            StartReconnect()
+        End If
+    End Sub
 
-        Private Sub PopulateComPorts()
-            ComPortMenuItem.Items.Clear()
-            Dim autoItem = New MenuItem() With {.Header = "_Auto", .IsCheckable = True, .IsChecked = settings.ComPort = "Auto"}
-            AddHandler autoItem.Click, Sub() SetComPort("Auto")
-            ComPortMenuItem.Items.Add(autoItem)
-            For Each port In System.IO.Ports.SerialPort.GetPortNames()
-                Dim item = New MenuItem() With {.Header = port, .IsCheckable = True, .IsChecked = settings.ComPort = port}
-                AddHandler item.Click, Sub() SetComPort(port)
-                ComPortMenuItem.Items.Add(item)
-            Next
-        End Sub
+    Private Sub OnControllerDisconnected()
+        Dispatcher.Invoke(Sub()
+                               ConnectionText.Text = "Disconnected"
+                               StartReconnect()
+                           End Sub)
+    End Sub
 
-        Private Sub SetComPort(port As String)
-            settings.ComPort = port
+    Private Sub StartReconnect()
+        If reconnectTimer Is Nothing Then
+            reconnectTimer = New DispatcherTimer()
+            reconnectTimer.Interval = TimeSpan.FromSeconds(1)
+            AddHandler reconnectTimer.Tick, Sub() ConnectPort()
+            reconnectTimer.Start()
+        End If
+    End Sub
+
+    Private Sub StopReconnect()
+        If reconnectTimer IsNot Nothing Then
+            reconnectTimer.Stop()
+            reconnectTimer = Nothing
+        End If
+    End Sub
+
+    Private Sub KeyMappingMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles KeyMappingMenuItem.Click
+        Dim dlg = New KeyMappingWindow(settings.KeyMapping)
+        If dlg.ShowDialog() Then
             settings.Save()
-            PopulateComPorts()
-            ConnectPort()
-        End Sub
+            processor.Mapper = settings.KeyMapping
+        End If
+    End Sub
 
-        Private reconnectTimer As DispatcherTimer
+    Private Sub SimulatorMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles SimulatorMenuItem.Click
+        Dim sim As New HardwareSimulatorWindow(processor)
+        sim.Show()
+    End Sub
 
-        Private Sub ConnectPort()
-            If controller.Connect(settings.ComPort) Then
-                ConnectionText.Text = $"Connected to {controller.CurrentPort}"
-                StopReconnect()
-            Else
-                If String.IsNullOrWhiteSpace(controller.LastError) Then
-                    ConnectionText.Text = "Disconnected"
-                Else
-                    ConnectionText.Text = $"Error: {controller.LastError}"
-                End If
-                StartReconnect()
-            End If
-        End Sub
-
-        Private Sub OnControllerDisconnected()
-            Dispatcher.Invoke(Sub()
-                                   ConnectionText.Text = "Disconnected"
-                                   StartReconnect()
-                               End Sub)
-        End Sub
-
-        Private Sub StartReconnect()
-            If reconnectTimer Is Nothing Then
-                reconnectTimer = New DispatcherTimer()
-                reconnectTimer.Interval = TimeSpan.FromSeconds(1)
-                AddHandler reconnectTimer.Tick, Sub() ConnectPort()
-                reconnectTimer.Start()
-            End If
-        End Sub
-
-        Private Sub StopReconnect()
-            If reconnectTimer IsNot Nothing Then
-                reconnectTimer.Stop()
-                reconnectTimer = Nothing
-            End If
-        End Sub
-
-        Private Sub KeyMappingMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles KeyMappingMenuItem.Click
-            Dim dlg = New KeyMappingWindow(settings.KeyMapping)
-            If dlg.ShowDialog() Then
-                settings.Save()
-                processor.Mapper = settings.KeyMapping
-            End If
-        End Sub
-
-        Private Sub SimulatorMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles SimulatorMenuItem.Click
-            Dim sim As New HardwareSimulatorWindow(processor)
-            sim.Show()
-        End Sub
-
-        Private Sub OnStateChanged(sender As Object, e As EventArgs)
-            If WindowState = WindowState.Minimized Then
-                Me.Hide()
-            End If
-        End Sub
-    End Class
-End Namespace
+    Private Sub OnStateChanged(sender As Object, e As EventArgs)
+        If WindowState = WindowState.Minimized Then
+            Me.Hide()
+        End If
+    End Sub
+End Class

--- a/EncoderWpfApp/MainWindow.xaml.vb
+++ b/EncoderWpfApp/MainWindow.xaml.vb
@@ -25,6 +25,9 @@ Namespace EncoderWpfApp
 
         Public Sub New()
             InitializeComponent()
+            Dim appVersion = My.Application.Info.Version.ToString()
+            Me.Title = $"HomeCockpit  - Jonas Lang / Timo Boehme - V{appVersion}"
+            VersionText.Text = $"Version: {appVersion}"
             settings = AppSettings.Load()
             autoStart = New AutoStartManager("EncoderWpfApp", settings)
             AutostartMenuItem.IsChecked = autoStart.IsEnabled()


### PR DESCRIPTION
## Summary
- add bottom "Run All" button to simulator that triggers each hardware action at one-second intervals
- display application version dynamically from assembly info in main window title
- cover run-all behavior with unit test

## Testing
- `dotnet test EncoderLib.Tests`
- `dotnet test EncoderWpfApp.Tests` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5424e7d0833399c10a7ccfda59f1