### PR TITLE
feat: add usage tracking and statistics

### DIFF
--- a/EncoderLib.Tests/UsageTrackerTests.vb
+++ b/EncoderLib.Tests/UsageTrackerTests.vb
@@ -1,0 +1,22 @@
+Imports EncoderLib
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+'------------------------------------------------------------------------------
+'  Created: 2025-08-12
+'  Edited:  2025-08-12
+'  Author:  ChatGPT
+'  Description: Tests for UsageTracker.
+'------------------------------------------------------------------------------
+<TestClass>
+Public Class UsageTrackerTests
+    <TestMethod>
+    Public Sub RecordsEvents()
+        Dim tracker = New UsageTracker()
+        tracker.Record("Start")
+        tracker.Record("Start")
+        tracker.Record("Stop")
+        Dim snap = tracker.Snapshot()
+        Assert.AreEqual(2, snap("Start"))
+        Assert.AreEqual(1, snap("Stop"))
+    End Sub
+End Class

--- a/EncoderLib/UsageTracker.vb
+++ b/EncoderLib/UsageTracker.vb
@@ -1,0 +1,23 @@
+Imports System.Collections.Concurrent
+
+'------------------------------------------------------------------------------
+'  Created: 2025-08-12
+'  Edited:  2025-08-12
+'  Author:  ChatGPT
+'  Description: Records counts of named usage events.
+'------------------------------------------------------------------------------
+Public Class UsageTracker
+    Private ReadOnly counts As ConcurrentDictionary(Of String, Integer)
+
+    Public Sub New()
+        counts = New ConcurrentDictionary(Of String, Integer)(StringComparer.OrdinalIgnoreCase)
+    End Sub
+
+    Public Sub Record(eventName As String)
+        counts.AddOrUpdate(eventName, 1, Function(k, c) c + 1)
+    End Sub
+
+    Public Function Snapshot() As IReadOnlyDictionary(Of String, Integer)
+        Return New Dictionary(Of String, Integer)(counts)
+    End Function
+End Class

--- a/EncoderWpfApp/Application.xaml.vb
+++ b/EncoderWpfApp/Application.xaml.vb
@@ -1,12 +1,26 @@
 
 Imports System.Windows
 Imports System.Windows.Threading
+Imports EncoderLib
 
+'------------------------------------------------------------------------------
+'  Created: 2025-08-12
+'  Edited:  2025-08-12
+'  Author:  ChatGPT
+'  Description: Application entry point with usage tracking.
+'------------------------------------------------------------------------------
 Partial Public Class App
     Inherits Application
 
+    Public Shared ReadOnly Tracker As New UsageTracker()
+
     Public Sub New()
         ' Unhandled-Exception-Handler registrieren
+    End Sub
+
+    Protected Overrides Sub OnStartup(e As StartupEventArgs)
+        MyBase.OnStartup(e)
+        Tracker.Record("AppStarted")
     End Sub
 
     Private Sub Application_DispatcherUnhandledException(sender As Object, e As DispatcherUnhandledExceptionEventArgs) Handles Me.DispatcherUnhandledException
@@ -19,9 +33,7 @@ Partial Public Class App
 
     Private Sub Application_Exit(sender As Object, e As ExitEventArgs) Handles Me.Exit
 
-        ' Programmende loggen
+        Tracker.Record("AppExited")
     End Sub
-
-
 
 End Class

--- a/EncoderWpfApp/MainWindow.xaml
+++ b/EncoderWpfApp/MainWindow.xaml
@@ -12,6 +12,7 @@
                 <MenuItem x:Name="ComPortMenuItem" Header="_COM-Port" />
                 <MenuItem x:Name="KeyMappingMenuItem" Header="_Key Mapping" />
                 <MenuItem x:Name="SimulatorMenuItem" Header="_Simulator" />
+                <MenuItem x:Name="UsageMenuItem" Header="_Usage" />
             </MenuItem>
         </Menu>
         <StackPanel Margin="10">

--- a/EncoderWpfApp/MainWindow.xaml.vb
+++ b/EncoderWpfApp/MainWindow.xaml.vb
@@ -1,6 +1,6 @@
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-14
+'  Edited:  2025-08-12
 '  Author:  ChatGPT
 '  Description: Main window showing connection info and autostart.
 '------------------------------------------------------------------------------
@@ -46,6 +46,7 @@ Partial Class MainWindow
         If Environment.GetCommandLineArgs().Contains("--autostart") Then
             Me.Hide()
         End If
+        App.Tracker.Record("MainWindowOpened")
     End Sub
 
     Private Sub HandleLine(line As String)
@@ -134,6 +135,7 @@ Partial Class MainWindow
     End Sub
 
     Private Sub KeyMappingMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles KeyMappingMenuItem.Click
+        App.Tracker.Record("KeyMappingOpened")
         Dim dlg = New KeyMappingWindow(settings.KeyMapping)
         If dlg.ShowDialog() Then
             settings.Save()
@@ -142,8 +144,15 @@ Partial Class MainWindow
     End Sub
 
     Private Sub SimulatorMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles SimulatorMenuItem.Click
+        App.Tracker.Record("SimulatorOpened")
         Dim sim As New HardwareSimulatorWindow(processor)
         sim.Show()
+    End Sub
+
+    Private Sub UsageMenuItem_Click(sender As Object, e As RoutedEventArgs) Handles UsageMenuItem.Click
+        App.Tracker.Record("UsageStatsOpened")
+        Dim win As New UsageStatisticsWindow()
+        win.Show()
     End Sub
 
     Private Sub OnStateChanged(sender As Object, e As EventArgs)

--- a/EncoderWpfApp/UsageStatisticsWindow.xaml
+++ b/EncoderWpfApp/UsageStatisticsWindow.xaml
@@ -1,0 +1,18 @@
+<Window x:Class="UsageStatisticsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Usage Statistics" Height="300" Width="400">
+    <ScrollViewer>
+        <ItemsControl ItemsSource="{Binding}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Margin="5">
+                        <TextBlock Text="{Binding Name}" Width="150" />
+                        <Rectangle Height="20" Width="{Binding Width}" Fill="SteelBlue" />
+                        <TextBlock Text="{Binding Count}" Margin="5,0,0,0" />
+                    </StackPanel>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </ScrollViewer>
+</Window>

--- a/EncoderWpfApp/UsageStatisticsWindow.xaml.vb
+++ b/EncoderWpfApp/UsageStatisticsWindow.xaml.vb
@@ -1,0 +1,31 @@
+Imports System.Windows
+Imports System.Linq
+Imports EncoderLib
+
+'------------------------------------------------------------------------------
+'  Created: 2025-08-12
+'  Edited:  2025-08-12
+'  Author:  ChatGPT
+'  Description: Displays logged usage statistics.
+'------------------------------------------------------------------------------
+Partial Public Class UsageStatisticsWindow
+    Inherits Window
+
+    Private Class StatItem
+        Public Property Name As String
+        Public Property Count As Integer
+        Public Property Width As Double
+    End Class
+
+    Public Sub New()
+        InitializeComponent()
+        Dim stats = App.Tracker.Snapshot()
+        Dim max = If(stats.Count > 0, stats.Values.Max(), 1)
+        Dim items = stats.Select(Function(kv) New StatItem With {
+                                     .Name = kv.Key,
+                                     .Count = kv.Value,
+                                     .Width = (kv.Value / max) * 200
+                                 }).ToList()
+        DataContext = items
+    End Sub
+End Class


### PR DESCRIPTION
## Summary
- add `UsageTracker` to record named usage events
- show usage statistics in new WPF window with simple bar chart
- wire up tracking in `App` and `MainWindow`

## Testing
- `dotnet test` *(fails: You must install or update .NET to run this application for EncoderWpfApp.Tests)*
- `dotnet test EncoderLib.Tests/EncoderLib.Tests.vbproj`
- `dotnet build EncoderWpfApp/EncoderWpfApp.vbproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689bc45049d883338a8a5eb934e5a167