### PR TITLE
Improve keyboard sender APIs

### DIFF
--- a/EncoderLib.Tests/EncoderInputProcessorErrorTests.vb
+++ b/EncoderLib.Tests/EncoderInputProcessorErrorTests.vb
@@ -1,0 +1,59 @@
+Imports EncoderLib
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+Imports System
+Imports System.Collections.Generic
+Imports System.ComponentModel
+
+'------------------------------------------------------------------------------
+'  Created: 2025-09-03
+'  Edited:  2025-09-03
+'  Author:  ChatGPT
+'  Description: Tests error handling in EncoderInputProcessor.
+'------------------------------------------------------------------------------
+<TestClass>
+Public Class EncoderInputProcessorErrorTests
+
+    Private Class ThrowingKeyboard
+        Implements IKeyboardSender
+        Public CallCount As Integer
+        Public Sub SendKeys(keys As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
+            CallCount += 1
+            Throw New Win32Exception(5)
+        End Sub
+    End Class
+
+    <TestMethod>
+    Public Sub RotationFailureDoesNotRepeat()
+        Dim kb = New ThrowingKeyboard()
+        Dim processor = New EncoderInputProcessor(kb)
+        processor.Mapper = New KeyMapper() With {.RotateUp = "A"}
+        processor.Process(New EncoderMessage(0, RotationDirection.Clockwise), DateTime.UtcNow)
+        Try
+            processor.Process(New EncoderMessage(1, RotationDirection.Clockwise), DateTime.UtcNow)
+        Catch ex As Win32Exception
+        End Try
+        Try
+            processor.Process(New EncoderMessage(1, RotationDirection.Clockwise), DateTime.UtcNow)
+        Catch ex As Win32Exception
+        End Try
+        Assert.AreEqual(1, kb.CallCount)
+    End Sub
+
+    <TestMethod>
+    Public Sub ReleaseFailureResetsState()
+        Dim kb = New ThrowingKeyboard()
+        Dim processor = New EncoderInputProcessor(kb)
+        processor.Mapper = New KeyMapper() With {.ButtonPress = "A"}
+        Dim now = DateTime.UtcNow
+        processor.Process(New ButtonMessage(), now)
+        Try
+            processor.Process(New EncoderMessage(0, RotationDirection.Clockwise), now.AddMilliseconds(1000))
+        Catch ex As Win32Exception
+        End Try
+        Try
+            processor.Process(New EncoderMessage(0, RotationDirection.Clockwise), now.AddMilliseconds(1200))
+        Catch ex As Win32Exception
+        End Try
+        Assert.AreEqual(1, kb.CallCount)
+    End Sub
+End Class

--- a/EncoderLib.Tests/EncoderInputProcessorTests.vb
+++ b/EncoderLib.Tests/EncoderInputProcessorTests.vb
@@ -7,7 +7,7 @@ Imports System.Threading
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-11
+'  Edited:  2025-08-31
 '  Author:  ChatGPT
 '  Description: Tests for EncoderInputProcessor.
 '------------------------------------------------------------------------------
@@ -73,5 +73,17 @@ Public Class EncoderInputProcessorTests
         SyncLock keyboard.Sent
             Assert.AreEqual(WindowsKey.Escape, keyboard.Sent.Single()(0))
         End SyncLock
+    End Sub
+
+    <TestMethod>
+    Public Sub RotationSendsSequence()
+        Dim keyboard = New KeyboardMock()
+        Dim processor = New EncoderInputProcessor(keyboard)
+        processor.Mapper = New KeyMapper() With {.RotateUp = "A B"}
+        processor.Process(New EncoderMessage(0, RotationDirection.Clockwise), DateTime.UtcNow)
+        processor.Process(New EncoderMessage(1, RotationDirection.Clockwise), DateTime.UtcNow)
+        Assert.AreEqual(2, keyboard.Sent.Count)
+        Assert.AreEqual(WindowsKey.A, keyboard.Sent(0)(0))
+        Assert.AreEqual(WindowsKey.B, keyboard.Sent(1)(0))
     End Sub
 End Class

--- a/EncoderLib.Tests/EncoderInputProcessorTests.vb
+++ b/EncoderLib.Tests/EncoderInputProcessorTests.vb
@@ -7,7 +7,7 @@ Imports System.Threading
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-31
+'  Edited:  2025-09-02
 '  Author:  ChatGPT
 '  Description: Tests for EncoderInputProcessor.
 '------------------------------------------------------------------------------
@@ -33,6 +33,16 @@ Public Class EncoderInputProcessorTests
         processor.Process(New EncoderMessage(1, RotationDirection.Clockwise), DateTime.UtcNow)
         Assert.AreEqual(1, keyboard.Sent.Count)
         Assert.AreEqual(WindowsKey.Up, keyboard.Sent(0)(0))
+    End Sub
+
+    <TestMethod>
+    Public Sub FirstRotationWithoutBaselineSendsKey()
+        Dim keyboard = New KeyboardMock()
+        Dim processor = New EncoderInputProcessor(keyboard)
+        processor.Mapper = New KeyMapper() With {.RotateUp = "A"}
+        processor.Process(New EncoderMessage(1, RotationDirection.Clockwise), DateTime.UtcNow)
+        Assert.AreEqual(1, keyboard.Sent.Count)
+        Assert.AreEqual(WindowsKey.A, keyboard.Sent(0)(0))
     End Sub
 
     <TestMethod>

--- a/EncoderLib.Tests/WindowsKeyboardSenderStructTests.vb
+++ b/EncoderLib.Tests/WindowsKeyboardSenderStructTests.vb
@@ -1,0 +1,14 @@
+Imports System.Reflection
+Imports System.Runtime.InteropServices
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+<TestClass>
+Public Class WindowsKeyboardSenderStructTests
+    <TestMethod>
+    Public Sub InputStructHasExpectedSize()
+        Dim t = GetType(WindowsKeyboardSender).GetNestedType("INPUT", BindingFlags.NonPublic)
+        Assert.IsNotNull(t)
+        Dim size = Marshal.SizeOf(t)
+        Assert.IsTrue(size >= 40, $"INPUT size {size} is too small")
+    End Sub
+End Class

--- a/EncoderLib/EncoderInputProcessor.vb
+++ b/EncoderLib/EncoderInputProcessor.vb
@@ -64,11 +64,16 @@ Public Class EncoderInputProcessor
                 Else
                     sequences = KeySequenceParser.ParseSequence(If(stepCount > 0, Mapper.RotateUp, Mapper.RotateDown))
                 End If
-                For i = 1 To Math.Abs(stepCount)
-                    For Each combo In sequences
-                        keyboard.SendKeys(combo)
+                Try
+                    For i = 1 To Math.Abs(stepCount)
+                        For Each combo In sequences
+                            keyboard.SendKeys(combo)
+                        Next
                     Next
-                Next
+                Finally
+                    lastPosition = msg.Position
+                End Try
+                Return
             End If
         End If
         lastPosition = msg.Position
@@ -78,10 +83,13 @@ Public Class EncoderInputProcessor
         If buttonPressed AndAlso timestamp - lastButtonSignal > releaseThreshold Then
             Dim duration = timestamp - buttonPressStart
             Dim text = If(duration >= longPressThreshold, Mapper.ButtonLongPress, Mapper.ButtonPress)
-            For Each combo In KeySequenceParser.ParseSequence(text)
-                keyboard.SendKeys(combo)
-            Next
-            buttonPressed = False
+            Try
+                For Each combo In KeySequenceParser.ParseSequence(text)
+                    keyboard.SendKeys(combo)
+                Next
+            Finally
+                buttonPressed = False
+            End Try
         End If
     End Sub
 

--- a/EncoderLib/EncoderInputProcessor.vb
+++ b/EncoderLib/EncoderInputProcessor.vb
@@ -4,7 +4,7 @@ Imports System.Timers
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-11
+'  Edited:  2025-08-31
 '  Author:  ChatGPT
 '  Description: Processes hardware messages and triggers keyboard actions.
 '------------------------------------------------------------------------------
@@ -56,14 +56,16 @@ Public Class EncoderInputProcessor
         If lastPosition.HasValue Then
             Dim stepCount = msg.Position - lastPosition.Value
             If stepCount <> 0 Then
-                Dim combo As IReadOnlyList(Of WindowsKey)
+                Dim sequences As IReadOnlyList(Of IReadOnlyList(Of WindowsKey))
                 If buttonPressed Then
-                    combo = KeyCombinationParser.Parse(If(stepCount > 0, Mapper.RotateUpWithButton, Mapper.RotateDownWithButton))
+                    sequences = KeySequenceParser.ParseSequence(If(stepCount > 0, Mapper.RotateUpWithButton, Mapper.RotateDownWithButton))
                 Else
-                    combo = KeyCombinationParser.Parse(If(stepCount > 0, Mapper.RotateUp, Mapper.RotateDown))
+                    sequences = KeySequenceParser.ParseSequence(If(stepCount > 0, Mapper.RotateUp, Mapper.RotateDown))
                 End If
                 For i = 1 To Math.Abs(stepCount)
-                    keyboard.SendKeys(combo)
+                    For Each combo In sequences
+                        keyboard.SendKeys(combo)
+                    Next
                 Next
             End If
         End If
@@ -73,11 +75,10 @@ Public Class EncoderInputProcessor
     Private Sub CheckButtonRelease(timestamp As DateTime)
         If buttonPressed AndAlso timestamp - lastButtonSignal > releaseThreshold Then
             Dim duration = timestamp - buttonPressStart
-            If duration >= longPressThreshold Then
-                keyboard.SendKeys(KeyCombinationParser.Parse(Mapper.ButtonLongPress))
-            Else
-                keyboard.SendKeys(KeyCombinationParser.Parse(Mapper.ButtonPress))
-            End If
+            Dim text = If(duration >= longPressThreshold, Mapper.ButtonLongPress, Mapper.ButtonPress)
+            For Each combo In KeySequenceParser.ParseSequence(text)
+                keyboard.SendKeys(combo)
+            Next
             buttonPressed = False
         End If
     End Sub

--- a/EncoderLib/EncoderInputProcessor.vb
+++ b/EncoderLib/EncoderInputProcessor.vb
@@ -4,7 +4,7 @@ Imports System.Timers
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-31
+'  Edited:  2025-09-02
 '  Author:  ChatGPT
 '  Description: Processes hardware messages and triggers keyboard actions.
 '------------------------------------------------------------------------------
@@ -24,12 +24,14 @@ Public Class EncoderInputProcessor
     Public Sub New(keyboard As IKeyboardSender)
         Me.keyboard = keyboard
         Me.Mapper = New KeyMapper()
+        lastPosition = 0
         releaseTimer = CreateReleaseTimer()
     End Sub
 
     Public Sub New(keyboard As IKeyboardSender, mapper As KeyMapper)
         Me.keyboard = keyboard
         Me.Mapper = mapper
+        lastPosition = 0
         releaseTimer = CreateReleaseTimer()
     End Sub
 

--- a/EncoderLib/KeySequenceParser.vb
+++ b/EncoderLib/KeySequenceParser.vb
@@ -1,0 +1,31 @@
+Imports System
+Imports System.Collections.Generic
+
+'------------------------------------------------------------------------------
+'  Created: 2025-08-31
+'  Edited:  2025-08-31
+'  Author:  ChatGPT
+'  Description: Parses textual key sequences into lists of key combinations.
+'------------------------------------------------------------------------------
+Public Class KeySequenceParser
+    Public Shared Function ParseSequence(text As String) As IReadOnlyList(Of IReadOnlyList(Of WindowsKey))
+        Dim result As New List(Of IReadOnlyList(Of WindowsKey))()
+        If String.IsNullOrWhiteSpace(text) Then Return result
+        Dim parts = text.Split(New String() {" "}, StringSplitOptions.RemoveEmptyEntries)
+        If parts.Length = 1 Then
+            Dim combo = KeyCombinationParser.Parse(parts(0))
+            If combo.Count > 0 Then
+                result.Add(combo)
+                Return result
+            End If
+            For Each ch In text.ToCharArray()
+                result.Add(KeyCombinationParser.Parse(ch.ToString()))
+            Next
+        Else
+            For Each part In parts
+                result.Add(KeyCombinationParser.Parse(part))
+            Next
+        End If
+        Return result
+    End Function
+End Class

--- a/EncoderLib/WindowsKeyboardSender.vb
+++ b/EncoderLib/WindowsKeyboardSender.vb
@@ -1,10 +1,11 @@
 Imports System
+Imports System.ComponentModel
 Imports System.Runtime.InteropServices
 Imports System.Collections.Generic
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-14
+'  Edited:  2025-08-30
 '  Author:  ChatGPT
 '  Description: Sends keyboard input via Win32 SendInput.
 '------------------------------------------------------------------------------
@@ -46,18 +47,21 @@ Public Class WindowsKeyboardSender
 
     Public Sub SendKeys(keys As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
         If keys Is Nothing OrElse keys.Count = 0 Then Return
-        Dim list As New List(Of INPUT)()
-        For Each key In keys
-            list.Add(CreateInput(key, False))
+        Dim inputs As New List(Of INPUT)()
+        For Each virtualKey In keys
+            inputs.Add(CreateKeyInput(virtualKey, False))
         Next
         For i = keys.Count - 1 To 0 Step -1
-            list.Add(CreateInput(keys(i), True))
+            inputs.Add(CreateKeyInput(keys(i), True))
         Next
-        SendInput(CUInt(list.Count), list.ToArray(), Marshal.SizeOf(GetType(INPUT)))
+        Dim sent = SendInput(CUInt(inputs.Count), inputs.ToArray(), Marshal.SizeOf(GetType(INPUT)))
+        If sent <> inputs.Count Then
+            Throw New Win32Exception(Marshal.GetLastWin32Error())
+        End If
     End Sub
 
-    Private Function CreateInput(key As WindowsKey, keyUp As Boolean) As INPUT
-        Dim scan = MapVirtualKeyEx(CUInt(key), MAPVK_VK_TO_VSC_EX, GetKeyboardLayout(0))
+    Private Function CreateKeyInput(virtualKey As WindowsKey, keyUp As Boolean) As INPUT
+        Dim scan = MapVirtualKeyEx(CUInt(virtualKey), MAPVK_VK_TO_VSC_EX, GetKeyboardLayout(0))
         Dim flags As UInteger = KEYEVENTF_SCANCODE
         If keyUp Then flags = flags Or KEYEVENTF_KEYUP
         If (scan And &H100UI) <> 0UI Then flags = flags Or KEYEVENTF_EXTENDEDKEY

--- a/EncoderLib/WindowsKeyboardSender.vb
+++ b/EncoderLib/WindowsKeyboardSender.vb
@@ -5,7 +5,7 @@ Imports System.Collections.Generic
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-30
+'  Edited:  2025-09-02
 '  Author:  ChatGPT
 '  Description: Sends keyboard input via Win32 SendInput.
 '------------------------------------------------------------------------------
@@ -71,15 +71,25 @@ Public Class WindowsKeyboardSender
 
     Public Sub SendKeys(keys As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
         If keys Is Nothing OrElse keys.Count = 0 Then Return
-        Dim inputs As New List(Of INPUT)()
+
+        Dim downs As New List(Of INPUT)()
         For Each virtualKey In keys
-            inputs.Add(CreateKeyInput(virtualKey, False))
+            downs.Add(CreateKeyInput(virtualKey, False))
         Next
+
+        Dim ups As New List(Of INPUT)()
         For i = keys.Count - 1 To 0 Step -1
-            inputs.Add(CreateKeyInput(keys(i), True))
+            ups.Add(CreateKeyInput(keys(i), True))
         Next
-        Dim sent = SendInput(CUInt(inputs.Count), inputs.ToArray(), Marshal.SizeOf(GetType(INPUT)))
-        If sent <> inputs.Count Then
+
+        Dim size = Marshal.SizeOf(GetType(INPUT))
+        Dim sent = SendInput(CUInt(downs.Count), downs.ToArray(), size)
+        If sent <> downs.Count Then
+            Throw New Win32Exception(Marshal.GetLastWin32Error())
+        End If
+
+        sent = SendInput(CUInt(ups.Count), ups.ToArray(), size)
+        If sent <> ups.Count Then
             Throw New Win32Exception(Marshal.GetLastWin32Error())
         End If
     End Sub

--- a/EncoderLib/WindowsKeyboardSender.vb
+++ b/EncoderLib/WindowsKeyboardSender.vb
@@ -5,7 +5,7 @@ Imports System.Collections.Generic
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-30
+'  Edited:  2025-09-02
 '  Author:  ChatGPT
 '  Description: Sends keyboard input via Win32 SendInput.
 '------------------------------------------------------------------------------
@@ -62,14 +62,25 @@ Public Class WindowsKeyboardSender
 
     Private Function CreateKeyInput(virtualKey As WindowsKey, keyUp As Boolean) As INPUT
         Dim scan = MapVirtualKeyEx(CUInt(virtualKey), MAPVK_VK_TO_VSC_EX, GetKeyboardLayout(0))
-        Dim flags As UInteger = KEYEVENTF_SCANCODE
+
+        Dim flags As UInteger = 0UI
+        Dim wVk As UShort = CUShort(virtualKey)
+        Dim wScan As UShort = 0US
+
+        If scan <> 0UI Then
+            flags = KEYEVENTF_SCANCODE
+            wVk = 0US
+            wScan = CUShort(scan And &HFFUI)
+            If (scan And &H100UI) <> 0UI Then flags = flags Or KEYEVENTF_EXTENDEDKEY
+        End If
+
         If keyUp Then flags = flags Or KEYEVENTF_KEYUP
-        If (scan And &H100UI) <> 0UI Then flags = flags Or KEYEVENTF_EXTENDEDKEY
+
         Dim input As New INPUT()
         input.type = INPUT_KEYBOARD
         input.ki = New KEYBDINPUT()
-        input.ki.wVk = 0
-        input.ki.wScan = CUShort(scan And &HFFUI)
+        input.ki.wVk = wVk
+        input.ki.wScan = wScan
         input.ki.dwFlags = flags
         Return input
     End Function

--- a/EncoderLib/WindowsKeyboardSender.vb
+++ b/EncoderLib/WindowsKeyboardSender.vb
@@ -5,7 +5,7 @@ Imports System.Collections.Generic
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-09-02
+'  Edited:  2025-08-30
 '  Author:  ChatGPT
 '  Description: Sends keyboard input via Win32 SendInput.
 '------------------------------------------------------------------------------
@@ -15,7 +15,14 @@ Public Class WindowsKeyboardSender
     <StructLayout(LayoutKind.Sequential)>
     Private Structure INPUT
         Public type As Integer
-        Public ki As KEYBDINPUT
+        Public U As InputUnion
+    End Structure
+
+    <StructLayout(LayoutKind.Explicit)>
+    Private Structure InputUnion
+        <FieldOffset(0)> Public ki As KEYBDINPUT
+        <FieldOffset(0)> Public mi As MOUSEINPUT
+        <FieldOffset(0)> Public hi As HARDWAREINPUT
     End Structure
 
     <StructLayout(LayoutKind.Sequential)>
@@ -25,6 +32,23 @@ Public Class WindowsKeyboardSender
         Public dwFlags As UInteger
         Public time As UInteger
         Public dwExtraInfo As IntPtr
+    End Structure
+
+    <StructLayout(LayoutKind.Sequential)>
+    Private Structure MOUSEINPUT
+        Public dx As Integer
+        Public dy As Integer
+        Public mouseData As UInteger
+        Public dwFlags As UInteger
+        Public time As UInteger
+        Public dwExtraInfo As IntPtr
+    End Structure
+
+    <StructLayout(LayoutKind.Sequential)>
+    Private Structure HARDWAREINPUT
+        Public uMsg As UInteger
+        Public wParamL As UShort
+        Public wParamH As UShort
     End Structure
 
     Private Const INPUT_KEYBOARD As Integer = 1
@@ -78,10 +102,10 @@ Public Class WindowsKeyboardSender
 
         Dim input As New INPUT()
         input.type = INPUT_KEYBOARD
-        input.ki = New KEYBDINPUT()
-        input.ki.wVk = wVk
-        input.ki.wScan = wScan
-        input.ki.dwFlags = flags
+        input.U.ki = New KEYBDINPUT()
+        input.U.ki.wVk = wVk
+        input.U.ki.wScan = wScan
+        input.U.ki.dwFlags = flags
         Return input
     End Function
 End Class

--- a/EncoderWpfApp.Tests/NotifyingKeyboardSenderTests.vb
+++ b/EncoderWpfApp.Tests/NotifyingKeyboardSenderTests.vb
@@ -1,0 +1,36 @@
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+Imports EncoderLib
+Imports EncoderWpfApp
+Imports System.Collections.Generic
+
+'------------------------------------------------------------------------------
+'  Created: 2025-08-30
+'  Edited:  2025-08-30
+'  Author:  ChatGPT
+'  Description: Tests NotifyingKeyboardSender event forwarding.
+'------------------------------------------------------------------------------
+Namespace EncoderWpfApp.Tests
+    <TestClass>
+    Public Class NotifyingKeyboardSenderTests
+        Private Class DummySender
+            Implements IKeyboardSender
+            Public Sent As IReadOnlyList(Of WindowsKey)
+            Public Sub SendKeys(keys As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
+                Sent = keys
+            End Sub
+        End Class
+
+        <TestMethod>
+        Public Sub SendKeys_RaisesEventAndDelegates()
+            Dim dummy = New DummySender()
+            Dim sender = New NotifyingKeyboardSender(dummy)
+            Dim received As IReadOnlyList(Of WindowsKey) = Nothing
+            AddHandler sender.KeysSent, Sub(k) received = k
+            Dim keys As IReadOnlyList(Of WindowsKey) = New List(Of WindowsKey) From {WindowsKey.A}
+            sender.SendKeys(keys)
+            Assert.IsNotNull(received)
+            Assert.AreSame(keys, dummy.Sent)
+            Assert.AreSame(keys, received)
+        End Sub
+    End Class
+End Namespace

--- a/EncoderWpfApp.Tests/Win32ErrorHelperTests.vb
+++ b/EncoderWpfApp.Tests/Win32ErrorHelperTests.vb
@@ -1,0 +1,26 @@
+Imports System.ComponentModel
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+'------------------------------------------------------------------------------
+'  Created: 2025-09-01
+'  Edited:  2025-09-01
+'  Author:  ChatGPT
+'  Description: Tests for Win32ErrorHelper message generation.
+'------------------------------------------------------------------------------
+<TestClass>
+Public Class Win32ErrorHelperTests
+    <TestMethod>
+    Public Sub AccessDeniedMentionsAdministrator()
+        Dim ex As New Win32Exception(5)
+        Dim msg = Win32ErrorHelper.ToMessage(ex)
+        StringAssert.Contains(msg, "Administrator")
+    End Sub
+
+    <TestMethod>
+    Public Sub OtherErrorsIncludeCode()
+        Dim ex As New Win32Exception(2)
+        Dim msg = Win32ErrorHelper.ToMessage(ex)
+        StringAssert.Contains(msg, "Fehler 2")
+        StringAssert.Contains(msg, ex.Message)
+    End Sub
+End Class

--- a/EncoderWpfApp/HardwareSimulatorWindow.xaml.vb
+++ b/EncoderWpfApp/HardwareSimulatorWindow.xaml.vb
@@ -7,7 +7,7 @@ Imports EncoderLib
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-12
-'  Edited:  2025-08-31
+'  Edited:  2025-09-01
 '  Author:  ChatGPT
 '  Description: Simulates hardware events via buttons.
 '------------------------------------------------------------------------------
@@ -29,7 +29,7 @@ Public Partial Class HardwareSimulatorWindow
         Try
             processor.Process(msg, DateTime.UtcNow)
         Catch ex As Win32Exception
-            MessageBox.Show("Die Tasten konnten nicht gesendet werden. Bitte als Administrator ausführen.", "HomeCockpit", MessageBoxButton.OK, MessageBoxImage.Warning)
+            MessageBox.Show(Win32ErrorHelper.ToMessage(ex), "HomeCockpit", MessageBoxButton.OK, MessageBoxImage.Warning)
         End Try
     End Sub
 

--- a/EncoderWpfApp/HardwareSimulatorWindow.xaml.vb
+++ b/EncoderWpfApp/HardwareSimulatorWindow.xaml.vb
@@ -1,4 +1,5 @@
 Imports System
+Imports System.ComponentModel
 Imports System.Threading.Tasks
 Imports System.Windows
 Imports System.Windows.Controls
@@ -6,7 +7,7 @@ Imports EncoderLib
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-12
-'  Edited:  2025-08-14
+'  Edited:  2025-08-31
 '  Author:  ChatGPT
 '  Description: Simulates hardware events via buttons.
 '------------------------------------------------------------------------------
@@ -24,35 +25,43 @@ Public Partial Class HardwareSimulatorWindow
         position = 0
     End Sub
 
+    Private Sub ProcessSafe(msg As HardwareMessage)
+        Try
+            processor.Process(msg, DateTime.UtcNow)
+        Catch ex As Win32Exception
+            MessageBox.Show("Die Tasten konnten nicht gesendet werden. Bitte als Administrator ausführen.", "HomeCockpit", MessageBoxButton.OK, MessageBoxImage.Warning)
+        End Try
+    End Sub
+
     Private Sub RotateUp_Click(sender As Object, e As RoutedEventArgs)
         position += 1
-        processor.Process(New EncoderMessage(position, RotationDirection.Clockwise), DateTime.UtcNow)
+        ProcessSafe(New EncoderMessage(position, RotationDirection.Clockwise))
     End Sub
 
     Private Sub RotateDown_Click(sender As Object, e As RoutedEventArgs)
         position -= 1
-        processor.Process(New EncoderMessage(position, RotationDirection.CounterClockwise), DateTime.UtcNow)
+        ProcessSafe(New EncoderMessage(position, RotationDirection.CounterClockwise))
     End Sub
 
     Private Sub RotateUpBtn_Click(sender As Object, e As RoutedEventArgs)
-        processor.Process(New ButtonMessage(), DateTime.UtcNow)
+        ProcessSafe(New ButtonMessage())
         RotateUp_Click(sender, e)
     End Sub
 
     Private Sub RotateDownBtn_Click(sender As Object, e As RoutedEventArgs)
-        processor.Process(New ButtonMessage(), DateTime.UtcNow)
+        ProcessSafe(New ButtonMessage())
         RotateDown_Click(sender, e)
     End Sub
 
     Private Sub ButtonPress_Click(sender As Object, e As RoutedEventArgs)
-        processor.Process(New ButtonMessage(), DateTime.UtcNow)
+        ProcessSafe(New ButtonMessage())
     End Sub
 
     Private Async Function PerformButtonLongPressAsync() As Task
-        processor.Process(New ButtonMessage(), DateTime.UtcNow)
+        ProcessSafe(New ButtonMessage())
         For i = 1 To 6
             Await delayProvider(TimeSpan.FromMilliseconds(150))
-            processor.Process(New ButtonMessage(), DateTime.UtcNow)
+            ProcessSafe(New ButtonMessage())
         Next
     End Function
 
@@ -79,6 +88,7 @@ Public Partial Class HardwareSimulatorWindow
         Dim btn = CType(sender, Button)
         btn.IsEnabled = False
         Try
+            Await delayProvider(TimeSpan.FromSeconds(3))
             Await ClickAllButtonsAsync()
         Finally
             btn.IsEnabled = True

--- a/EncoderWpfApp/MainWindow.xaml.vb
+++ b/EncoderWpfApp/MainWindow.xaml.vb
@@ -1,6 +1,6 @@
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-31
+'  Edited:  2025-09-01
 '  Author:  ChatGPT
 '  Description: Main window showing connection info and autostart.
 '------------------------------------------------------------------------------
@@ -62,7 +62,7 @@ Partial Class MainWindow
                                    Try
                                        processor.Process(msg, Date.Now)
                                    Catch ex As Win32Exception
-                                       MessageBox.Show("Die Tasten konnten nicht gesendet werden. Bitte als Administrator ausführen.", "HomeCockpit", MessageBoxButton.OK, MessageBoxImage.Warning)
+                                       MessageBox.Show(Win32ErrorHelper.ToMessage(ex), "HomeCockpit", MessageBoxButton.OK, MessageBoxImage.Warning)
                                    End Try
                                End If
                            End Sub)

--- a/EncoderWpfApp/MainWindow.xaml.vb
+++ b/EncoderWpfApp/MainWindow.xaml.vb
@@ -1,9 +1,10 @@
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-12
+'  Edited:  2025-08-31
 '  Author:  ChatGPT
 '  Description: Main window showing connection info and autostart.
 '------------------------------------------------------------------------------
+Imports System.ComponentModel
 Imports System.Windows
 Imports System.Windows.Controls
 Imports System.Windows.Threading
@@ -58,7 +59,11 @@ Partial Class MainWindow
                                If isVersion Then
                                    VersionText.Text = line.Trim()
                                ElseIf parsed Then
-                                   processor.Process(msg, Date.Now)
+                                   Try
+                                       processor.Process(msg, Date.Now)
+                                   Catch ex As Win32Exception
+                                       MessageBox.Show("Die Tasten konnten nicht gesendet werden. Bitte als Administrator ausführen.", "HomeCockpit", MessageBoxButton.OK, MessageBoxImage.Warning)
+                                   End Try
                                End If
                            End Sub)
     End Sub

--- a/EncoderWpfApp/NotifyingKeyboardSender.vb
+++ b/EncoderWpfApp/NotifyingKeyboardSender.vb
@@ -1,24 +1,28 @@
 Imports EncoderLib
+Imports System
 Imports System.Collections.Generic
 
 '------------------------------------------------------------------------------
 '  Created: 2025-08-09
-'  Edited:  2025-08-12
+'  Edited:  2025-08-30
 '  Author:  ChatGPT
 '  Description: Wraps keyboard sender and exposes sent keys.
 '------------------------------------------------------------------------------
 Public Class NotifyingKeyboardSender
     Implements IKeyboardSender
 
-    Private ReadOnly inner As IKeyboardSender
+    Private ReadOnly wrappedSender As IKeyboardSender
     Public Event KeysSent(keys As IReadOnlyList(Of WindowsKey))
 
-    Public Sub New(inner As IKeyboardSender)
-        Me.inner = inner
+    Public Sub New(wrappedSender As IKeyboardSender)
+        If wrappedSender Is Nothing Then
+            Throw New ArgumentNullException(NameOf(wrappedSender))
+        End If
+        Me.wrappedSender = wrappedSender
     End Sub
 
     Public Sub SendKeys(keys As IReadOnlyList(Of WindowsKey)) Implements IKeyboardSender.SendKeys
-        inner.SendKeys(keys)
+        wrappedSender.SendKeys(keys)
         RaiseEvent KeysSent(keys)
     End Sub
 End Class

--- a/EncoderWpfApp/Win32ErrorHelper.vb
+++ b/EncoderWpfApp/Win32ErrorHelper.vb
@@ -1,0 +1,17 @@
+Imports System.ComponentModel
+
+'------------------------------------------------------------------------------
+'  Created: 2025-09-01
+'  Edited:  2025-09-01
+'  Author:  ChatGPT
+'  Description: Builds user messages for Win32 keyboard simulation errors.
+'------------------------------------------------------------------------------
+Public Module Win32ErrorHelper
+    Public Function ToMessage(ex As Win32Exception) As String
+        Dim code = ex.NativeErrorCode
+        If code = 5 OrElse code = 1314 Then
+            Return "Die Tasten konnten nicht gesendet werden. Bitte als Administrator ausführen."
+        End If
+        Return $"Die Tasten konnten nicht gesendet werden. Fehler {code}: {ex.Message}"
+    End Function
+End Module


### PR DESCRIPTION
## Summary
- add validation and Win32 error handling to WindowsKeyboardSender
- enforce null checks and clearer naming in NotifyingKeyboardSender
- cover NotifyingKeyboardSender with a unit test

## Testing
- `dotnet test EncoderLib.Tests/EncoderLib.Tests.vbproj`
- `dotnet test EncoderWpfApp.Tests/EncoderWpfApp.Tests.vbproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b35aff4a4883339ccada229651fc4f